### PR TITLE
Secure paywall verification persistence and gating

### DIFF
--- a/includes/class-x402-paywall-activator.php
+++ b/includes/class-x402-paywall-activator.php
@@ -53,11 +53,14 @@ class X402_Paywall_Activator {
             token_address varchar(100) NOT NULL,
             network varchar(50) NOT NULL,
             transaction_hash varchar(100) DEFAULT NULL,
+            payer_identifier varchar(200) DEFAULT NULL,
+            settlement_proof longtext DEFAULT NULL,
             payment_status varchar(20) NOT NULL DEFAULT 'pending',
             created_at datetime DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY (id),
             KEY post_id (post_id),
             KEY user_address (user_address),
+            KEY payer_identifier (payer_identifier),
             KEY payment_status (payment_status),
             KEY created_at (created_at)
         ) $charset_collate;";


### PR DESCRIPTION
## Summary
- add payer identifier and settlement proof storage to the payment log schema
- move payment verification tracking to signed transients backed by authoritative database checks
- require confirmed settlement signatures and enforce a post-render 402 gate for unpaid requests

## Testing
- php -l public/class-x402-paywall-public.php
- php -l includes/class-x402-paywall-db.php
- php -l includes/class-x402-paywall-activator.php

------
https://chatgpt.com/codex/tasks/task_b_6902d15db7b883329806c4d9dad7b77e