### PR TITLE
Validate paywall amounts and store atomic values

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -157,7 +157,8 @@ This document summarizes the implementation of the X402 Paywall WordPress plugin
 - `_x402_paywall_network_type` - String (evm/spl)
 - `_x402_paywall_network` - String (base-mainnet, etc.)
 - `_x402_paywall_token_address` - String (contract address)
-- `_x402_paywall_amount` - Float (human-readable amount)
+- `_x402_paywall_amount` - String (token amount in atomic units)
+- `_x402_paywall_amount_format` - String flag for amount storage format
 - `_x402_paywall_token_decimals` - Integer (6 for USDC)
 - `_x402_paywall_token_name` - String (for EIP-712)
 - `_x402_paywall_token_version` - String (for EIP-712)


### PR DESCRIPTION
## Summary
- sanitize paywall settings input, convert valid amounts to atomic units, and surface admin error notices when validation fails
- update the meta box UI to format stored atomic amounts for editors and keep input precision aligned with token decimals
- adjust public paywall rendering to consume atomic amounts while maintaining backward compatibility with previously stored values

## Testing
- php -l admin/class-x402-paywall-meta-boxes.php
- php -l public/class-x402-paywall-public.php

------
https://chatgpt.com/codex/tasks/task_b_6902e2a51d0c8332b78357eedfa35ab1