### PR TITLE
Improve token label handling in paywall UI

### DIFF
--- a/admin/class-x402-paywall-meta-boxes.php
+++ b/admin/class-x402-paywall-meta-boxes.php
@@ -18,74 +18,14 @@ class X402_Paywall_Meta_Boxes {
     /**
      * Token configurations
      */
-    private $tokens = array(
-        'evm' => array(
-            'base-mainnet' => array(
-                'name' => 'Base Mainnet',
-                'tokens' => array(
-                    '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' => array(
-                        'name' => 'USDC',
-                        'decimals' => 6,
-                        'token_name' => 'USD Coin',
-                        'token_version' => '2',
-                    ),
-                ),
-            ),
-            'base-sepolia' => array(
-                'name' => 'Base Sepolia (Testnet)',
-                'tokens' => array(
-                    '0x036CbD53842c5426634e7929541eC2318f3dCF7e' => array(
-                        'name' => 'USDC',
-                        'decimals' => 6,
-                        'token_name' => 'USD Coin',
-                        'token_version' => '2',
-                    ),
-                ),
-            ),
-            'ethereum-mainnet' => array(
-                'name' => 'Ethereum Mainnet',
-                'tokens' => array(
-                    '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' => array(
-                        'name' => 'USDC',
-                        'decimals' => 6,
-                        'token_name' => 'USD Coin',
-                        'token_version' => '2',
-                    ),
-                ),
-            ),
-            'ethereum-sepolia' => array(
-                'name' => 'Ethereum Sepolia (Testnet)',
-                'tokens' => array(
-                    '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238' => array(
-                        'name' => 'USDC',
-                        'decimals' => 6,
-                        'token_name' => 'USD Coin',
-                        'token_version' => '2',
-                    ),
-                ),
-            ),
-        ),
-        'spl' => array(
-            'solana-mainnet' => array(
-                'name' => 'Solana Mainnet',
-                'tokens' => array(
-                    'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' => array(
-                        'name' => 'USDC',
-                        'decimals' => 6,
-                    ),
-                ),
-            ),
-            'solana-devnet' => array(
-                'name' => 'Solana Devnet (Testnet)',
-                'tokens' => array(
-                    '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU' => array(
-                        'name' => 'USDC',
-                        'decimals' => 6,
-                    ),
-                ),
-            ),
-        ),
-    );
+    private $tokens;
+
+    /**
+     * Constructor
+     */
+    public function __construct() {
+        $this->tokens = X402_Paywall_Token_Registry::get_all();
+    }
     
     /**
      * Initialize meta boxes
@@ -486,10 +426,7 @@ class X402_Paywall_Meta_Boxes {
      * @return array|null Token configuration
      */
     public function get_token_config($network_type, $network, $token_address) {
-        if (isset($this->tokens[$network_type][$network]['tokens'][$token_address])) {
-            return $this->tokens[$network_type][$network]['tokens'][$token_address];
-        }
-        return null;
+        return X402_Paywall_Token_Registry::get_token($network_type, $network, $token_address);
     }
 
     /**

--- a/includes/class-x402-paywall-token-registry.php
+++ b/includes/class-x402-paywall-token-registry.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Token registry for supported networks
+ *
+ * @package X402_Paywall
+ */
+
+// Exit if accessed directly
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Provides token configuration metadata for supported networks.
+ */
+class X402_Paywall_Token_Registry {
+    /**
+     * Get all supported token configurations.
+     *
+     * @return array
+     */
+    public static function get_all() {
+        return array(
+            'evm' => array(
+                'base-mainnet' => array(
+                    'name' => 'Base Mainnet',
+                    'tokens' => array(
+                        '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' => array(
+                            'name' => 'USDC',
+                            'decimals' => 6,
+                            'token_name' => 'USD Coin',
+                            'token_version' => '2',
+                        ),
+                    ),
+                ),
+                'base-sepolia' => array(
+                    'name' => 'Base Sepolia (Testnet)',
+                    'tokens' => array(
+                        '0x036CbD53842c5426634e7929541eC2318f3dCF7e' => array(
+                            'name' => 'USDC',
+                            'decimals' => 6,
+                            'token_name' => 'USD Coin',
+                            'token_version' => '2',
+                        ),
+                    ),
+                ),
+                'ethereum-mainnet' => array(
+                    'name' => 'Ethereum Mainnet',
+                    'tokens' => array(
+                        '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' => array(
+                            'name' => 'USDC',
+                            'decimals' => 6,
+                            'token_name' => 'USD Coin',
+                            'token_version' => '2',
+                        ),
+                    ),
+                ),
+                'ethereum-sepolia' => array(
+                    'name' => 'Ethereum Sepolia (Testnet)',
+                    'tokens' => array(
+                        '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238' => array(
+                            'name' => 'USDC',
+                            'decimals' => 6,
+                            'token_name' => 'USD Coin',
+                            'token_version' => '2',
+                        ),
+                    ),
+                ),
+            ),
+            'spl' => array(
+                'solana-mainnet' => array(
+                    'name' => 'Solana Mainnet',
+                    'tokens' => array(
+                        'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' => array(
+                            'name' => 'USDC',
+                            'decimals' => 6,
+                        ),
+                    ),
+                ),
+                'solana-devnet' => array(
+                    'name' => 'Solana Devnet (Testnet)',
+                    'tokens' => array(
+                        '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU' => array(
+                            'name' => 'USDC',
+                            'decimals' => 6,
+                        ),
+                    ),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Get the token configuration for a specific network/token pair.
+     *
+     * @param string $network_type Network type (e.g. evm, spl).
+     * @param string $network Network identifier.
+     * @param string $token_address Token contract/mint address.
+     * @return array|null
+     */
+    public static function get_token($network_type, $network, $token_address) {
+        $tokens = self::get_all();
+
+        if (isset($tokens[$network_type][$network]['tokens'][$token_address])) {
+            return $tokens[$network_type][$network]['tokens'][$token_address];
+        }
+
+        return null;
+    }
+}

--- a/includes/class-x402-paywall.php
+++ b/includes/class-x402-paywall.php
@@ -36,6 +36,7 @@ class X402_Paywall {
         // Core classes
         require_once X402_PAYWALL_PLUGIN_DIR . 'includes/class-x402-paywall-db.php';
         require_once X402_PAYWALL_PLUGIN_DIR . 'includes/class-x402-paywall-payment-handler.php';
+        require_once X402_PAYWALL_PLUGIN_DIR . 'includes/class-x402-paywall-token-registry.php';
         
         // Admin classes
         if (is_admin()) {

--- a/public/class-x402-paywall-public.php
+++ b/public/class-x402-paywall-public.php
@@ -1062,6 +1062,7 @@ class X402_Paywall_Public {
         $decimals = isset($paywall_config['token_decimals']) ? (int) $paywall_config['token_decimals'] : (int) get_post_meta($post_id, '_x402_paywall_token_decimals', true);
 
         $amount_display = $this->format_atomic_amount($amount_atomic, $decimals);
+        $token_label = $this->get_token_display_label($post_id, $paywall_config);
         
         // Get excerpt or first 150 characters
         global $post;
@@ -1082,7 +1083,7 @@ class X402_Paywall_Public {
                 <div class="x402-paywall-details">
                     <div class="x402-paywall-price">
                         <span class="x402-paywall-amount"><?php echo esc_html($amount_display); ?></span>
-                        <span class="x402-paywall-currency">USDC</span>
+                        <span class="x402-paywall-currency"><?php echo esc_html($token_label); ?></span>
                     </div>
                     <div class="x402-paywall-network">
                         <?php 
@@ -1093,7 +1094,7 @@ class X402_Paywall_Public {
                         ?>
                     </div>
                 </div>
-                
+
                 <div class="x402-paywall-instructions">
                     <p><?php esc_html_e('To access this content:', 'x402-paywall'); ?></p>
                     <ol>
@@ -1115,6 +1116,45 @@ class X402_Paywall_Public {
         </div>
         <?php
         return ob_get_clean();
+    }
+
+    /**
+     * Get a human-readable token label for the paywall UI.
+     *
+     * @param int   $post_id        Post identifier.
+     * @param array $paywall_config Paywall configuration array.
+     * @return string
+     */
+    private function get_token_display_label($post_id, $paywall_config) {
+        if (!empty($paywall_config['token_name'])) {
+            return $paywall_config['token_name'];
+        }
+
+        $meta_token_name = get_post_meta($post_id, '_x402_paywall_token_name', true);
+        if (!empty($meta_token_name)) {
+            return $meta_token_name;
+        }
+
+        $network_type = $paywall_config['network_type'] ?? '';
+        $network = $paywall_config['network'] ?? '';
+        $token_address = $paywall_config['token_address'] ?? '';
+
+        $token_config = X402_Paywall_Token_Registry::get_token($network_type, $network, $token_address);
+        if (is_array($token_config)) {
+            if (!empty($token_config['name'])) {
+                return $token_config['name'];
+            }
+
+            if (!empty($token_config['token_name'])) {
+                return $token_config['token_name'];
+            }
+        }
+
+        if (!empty($token_address)) {
+            return $token_address;
+        }
+
+        return esc_html__('Payment Token', 'x402-paywall');
     }
 
     /**


### PR DESCRIPTION
## Summary
- centralize token configuration data in a reusable token registry
- update meta box setup to consume the shared registry
- render paywall pricing with the configured token label, including metadata and fallback handling

## Testing
- php -l includes/class-x402-paywall-token-registry.php
- php -l admin/class-x402-paywall-meta-boxes.php
- php -l public/class-x402-paywall-public.php

------
https://chatgpt.com/codex/tasks/task_b_6902f98fc7808332b1e74e2faca9e70d