### PR TITLE
Improve failed payment handling feedback

### DIFF
--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -38,6 +38,60 @@
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
+.x402-paywall-error-notice {
+    position: relative;
+    text-align: left;
+    background: #fef2f2;
+    border: 1px solid #fca5a5;
+    color: #7f1d1d;
+    border-radius: 10px;
+    padding: 16px 18px 18px 18px;
+    margin-bottom: 20px;
+}
+
+.x402-paywall-error-header {
+    font-weight: 600;
+    margin-bottom: 6px;
+    font-size: 16px;
+}
+
+.x402-paywall-error-message {
+    margin: 0 0 6px 0;
+    font-size: 14px;
+}
+
+.x402-paywall-error-meta,
+.x402-paywall-error-reference {
+    margin: 0;
+    font-size: 13px;
+    color: #991b1b;
+}
+
+.x402-paywall-error-reference {
+    margin-top: 4px;
+    font-weight: 500;
+}
+
+.x402-paywall-error-dismiss {
+    position: absolute;
+    top: 10px;
+    right: 12px;
+    background: transparent;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 600;
+    padding: 4px 6px;
+    border-radius: 4px;
+}
+
+.x402-paywall-error-dismiss:hover,
+.x402-paywall-error-dismiss:focus {
+    background: rgba(127, 29, 29, 0.1);
+    outline: none;
+}
+
 .x402-paywall-icon {
     font-size: 64px;
     margin-bottom: 20px;
@@ -157,7 +211,11 @@
     .x402-paywall-message {
         padding: 30px 20px;
     }
-    
+
+    .x402-paywall-error-notice {
+        padding-right: 56px;
+    }
+
     .x402-paywall-icon {
         font-size: 48px;
     }
@@ -185,7 +243,11 @@
         padding: 20px 15px;
         border-radius: 8px;
     }
-    
+
+    .x402-paywall-error-notice {
+        padding: 14px 50px 16px 16px;
+    }
+
     .x402-paywall-message h3 {
         font-size: 20px;
     }

--- a/assets/js/public.js
+++ b/assets/js/public.js
@@ -6,12 +6,150 @@
 
 (function($) {
     'use strict';
-    
+
+    function getCookie(name) {
+        var nameEQ = name + '=';
+        var cookies = document.cookie ? document.cookie.split(';') : [];
+
+        for (var i = 0; i < cookies.length; i++) {
+            var cookie = cookies[i].trim();
+
+            if (cookie.indexOf(nameEQ) === 0) {
+                return cookie.substring(nameEQ.length);
+            }
+        }
+
+        return null;
+    }
+
+    function deleteCookie(name, path) {
+        var attributes = ['Max-Age=0', 'path=' + (path || '/'), 'SameSite=Lax'];
+
+        if (window.location && window.location.protocol === 'https:') {
+            attributes.push('Secure');
+        }
+
+        document.cookie = name + '=; ' + attributes.join('; ');
+    }
+
+    function decodeErrorPayload(rawValue) {
+        if (typeof rawValue !== 'string' || rawValue === '') {
+            return null;
+        }
+
+        if (typeof window.atob !== 'function') {
+            return null;
+        }
+
+        try {
+            var decoded = decodeURIComponent(rawValue);
+            var json = window.atob(decoded);
+            return JSON.parse(json);
+        } catch (error) {
+            console.error('X402 Paywall: Failed to decode error payload', error);
+            return null;
+        }
+    }
+
+    function buildMetaText(data) {
+        var parts = [];
+
+        if (data.status) {
+            parts.push('HTTP ' + data.status);
+        }
+
+        if (data.code) {
+            parts.push(data.code);
+        }
+
+        return parts.length ? parts.join(' · ') : '';
+    }
+
+    function getLocalizedString(key, fallback) {
+        if (window.x402PaywallData && Object.prototype.hasOwnProperty.call(window.x402PaywallData, key)) {
+            return window.x402PaywallData[key];
+        }
+
+        return fallback;
+    }
+
+    function renderErrorNotice(data) {
+        var container = document.querySelector('.x402-paywall-message');
+
+        if (!container) {
+            return;
+        }
+
+        var message = data.message || getLocalizedString('defaultErrorMessage', 'We were unable to verify your payment. Please try again.');
+        var metaText = buildMetaText(data);
+        var referenceLabel = getLocalizedString('referenceLabel', 'Support reference: %s');
+        var dismissLabel = getLocalizedString('dismissLabel', 'Dismiss');
+        var heading = getLocalizedString('errorTitle', 'Payment Error');
+
+        var notice = document.createElement('div');
+        notice.className = 'x402-paywall-error-notice';
+        notice.setAttribute('role', 'alert');
+        notice.setAttribute('aria-live', 'polite');
+
+        var title = document.createElement('div');
+        title.className = 'x402-paywall-error-header';
+        title.textContent = heading;
+        notice.appendChild(title);
+
+        var body = document.createElement('p');
+        body.className = 'x402-paywall-error-message';
+        body.textContent = message;
+        notice.appendChild(body);
+
+        if (metaText) {
+            var meta = document.createElement('p');
+            meta.className = 'x402-paywall-error-meta';
+            meta.textContent = metaText;
+            notice.appendChild(meta);
+        }
+
+        if (data.reference) {
+            var reference = document.createElement('p');
+            reference.className = 'x402-paywall-error-reference';
+            reference.textContent = referenceLabel.replace('%s', data.reference);
+            notice.appendChild(reference);
+        }
+
+        var dismissButton = document.createElement('button');
+        dismissButton.type = 'button';
+        dismissButton.className = 'x402-paywall-error-dismiss';
+        dismissButton.setAttribute('aria-label', dismissLabel);
+        dismissButton.textContent = dismissLabel;
+        dismissButton.addEventListener('click', function() {
+            notice.remove();
+        });
+
+        notice.appendChild(dismissButton);
+
+        container.insertBefore(notice, container.firstChild);
+    }
+
+    function displayErrorFromCookie() {
+        var rawPayload = getCookie('x402_paywall_error');
+
+        if (!rawPayload) {
+            return;
+        }
+
+        var path = getLocalizedString('cookiePath', '/');
+        deleteCookie('x402_paywall_error', path);
+
+        var data = decodeErrorPayload(rawPayload);
+
+        if (!data) {
+            return;
+        }
+
+        renderErrorNotice(data);
+    }
+
     $(document).ready(function() {
-        // Public JavaScript functionality
-        // Can be extended to support x402 payment client libraries
-        
-        console.log('X402 Paywall Public JS loaded');
+        displayErrorFromCookie();
     });
-    
+
 })(jQuery);


### PR DESCRIPTION
## Summary
- log facilitator failures from `process_payment_request` and surface support references via JSON responses or frontend notices
- extend the payment handler wrapper with structured error metadata for status codes and facilitator messages
- add localized JavaScript and styling so paywall pages display graceful error banners when a payment attempt is rejected

## Testing
- php -l includes/class-x402-paywall-payment-handler.php
- php -l public/class-x402-paywall-public.php

------
https://chatgpt.com/codex/tasks/task_b_6902f9ad59588332ac734195fcf9abe2