### PR TITLE
Capture facilitator error metadata in payment logs

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -149,6 +149,9 @@ This document summarizes the implementation of the X402 Paywall WordPress plugin
 - `network` - Network identifier
 - `transaction_hash` - Blockchain transaction hash
 - `payment_status` - Status (pending, verified, failed)
+- `failure_status_code` - HTTP status returned for failed facilitator requests
+- `facilitator_error_code` - Error code returned by facilitator, if any
+- `facilitator_message` - Raw facilitator failure description
 - `created_at` - Timestamp
 
 ### Post Meta Keys

--- a/includes/class-x402-paywall-activator.php
+++ b/includes/class-x402-paywall-activator.php
@@ -59,6 +59,9 @@ class X402_Paywall_Activator {
             payment_status varchar(20) NOT NULL DEFAULT 'pending',
             facilitator_signature text DEFAULT NULL,
             facilitator_reference varchar(191) DEFAULT NULL,
+            failure_status_code smallint(5) DEFAULT NULL,
+            facilitator_error_code varchar(191) DEFAULT NULL,
+            facilitator_message text DEFAULT NULL,
             created_at datetime DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY (id),
             KEY post_id (post_id),
@@ -67,6 +70,8 @@ class X402_Paywall_Activator {
             KEY payer_identifier (payer_identifier),
             KEY payment_status (payment_status),
             KEY facilitator_reference (facilitator_reference),
+            KEY failure_status_code (failure_status_code),
+            KEY facilitator_error_code (facilitator_error_code),
             KEY created_at (created_at)
         ) $charset_collate;";
         

--- a/includes/class-x402-paywall-db.php
+++ b/includes/class-x402-paywall-db.php
@@ -110,10 +110,39 @@ class X402_Paywall_DB {
             'facilitator_reference' => $payment_data['facilitator_reference'] ?? null,
         );
 
+        $format = array('%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s');
+
+        if (isset($payment_data['failure_status_code'])) {
+            $failure_status_code = (int) $payment_data['failure_status_code'];
+
+            if ($failure_status_code > 0) {
+                $data['failure_status_code'] = $failure_status_code;
+                $format[] = '%d';
+            }
+        }
+
+        if (isset($payment_data['facilitator_error_code'])) {
+            $facilitator_error_code = trim((string) $payment_data['facilitator_error_code']);
+
+            if ($facilitator_error_code !== '') {
+                $data['facilitator_error_code'] = $facilitator_error_code;
+                $format[] = '%s';
+            }
+        }
+
+        if (isset($payment_data['facilitator_message'])) {
+            $facilitator_message = trim((string) $payment_data['facilitator_message']);
+
+            if ($facilitator_message !== '') {
+                $data['facilitator_message'] = $facilitator_message;
+                $format[] = '%s';
+            }
+        }
+
         $result = $wpdb->insert(
             $table_name,
             $data,
-            array('%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s')
+            $format
         );
 
         return $result ? $wpdb->insert_id : false;

--- a/public/class-x402-paywall-public.php
+++ b/public/class-x402-paywall-public.php
@@ -437,6 +437,10 @@ class X402_Paywall_Public {
             ? trim($error_details['facilitator_message'])
             : '';
 
+        if ($facilitator_message !== '') {
+            $facilitator_message = wp_strip_all_tags($facilitator_message);
+        }
+
         $raw_message = isset($error_details['message']) && is_string($error_details['message'])
             ? $error_details['message']
             : __('Unable to verify the payment with the facilitator.', 'x402-paywall');
@@ -474,6 +478,9 @@ class X402_Paywall_Public {
             'payment_status' => 'failed',
             'facilitator_signature' => null,
             'facilitator_reference' => $facilitator_reference,
+            'failure_status_code' => $status_code,
+            'facilitator_error_code' => $error_code,
+            'facilitator_message' => $facilitator_message,
         );
 
         $encoded_error = $this->encode_error_payload_for_storage($error_details, $status_code, $facilitator_message, $sanitized_message, $error_code);


### PR DESCRIPTION
## Summary
- add storage for facilitator status codes, messages, and error codes in payment log schema
- capture and sanitize facilitator error payload when logging failed payment attempts
- document the additional log metadata in the implementation summary

## Testing
- php -l includes/class-x402-paywall-db.php
- php -l public/class-x402-paywall-public.php
- php -l includes/class-x402-paywall-activator.php

------
https://chatgpt.com/codex/tasks/task_b_69031e99fa948332bfc00da765db0d33