### PR TITLE
Align client config with saved paywall options

### DIFF
--- a/includes/class-x402-paywall-x402-client.php
+++ b/includes/class-x402-paywall-x402-client.php
@@ -23,6 +23,13 @@ class X402_Paywall_X402_Client {
      * @var mixed
      */
     private $client = null;
+
+    /**
+     * Cached configuration used for client initialization
+     *
+     * @var array
+     */
+    private $config = array();
     
     /**
      * Library available flag
@@ -46,6 +53,7 @@ class X402_Paywall_X402_Client {
      */
     private function __construct() {
         $this->load_library();
+        $this->config = $this->build_client_config();
         $this->init_client();
     }
     
@@ -80,14 +88,7 @@ class X402_Paywall_X402_Client {
         }
         
         try {
-            $config = array(
-                'network' => get_option('x402_default_network', 'mainnet'),
-                'api_endpoint' => get_option('x402_api_endpoint', ''),
-                'timeout' => 30,
-                'verify_ssl' => true,
-            );
-            
-            $config = apply_filters('x402_client_config', $config);
+            $config = $this->config;
             
             // Try to instantiate based on available classes
             if (class_exists('\X402\Client')) {
@@ -114,7 +115,46 @@ class X402_Paywall_X402_Client {
             }
         }
     }
-    
+
+    /**
+     * Build configuration array from stored options
+     *
+     * @return array
+     */
+    private function build_client_config() {
+        $facilitator_url = get_option('x402_paywall_facilitator_url', 'https://facilitator.x402.org');
+        $auto_settle = get_option('x402_paywall_auto_settle', '1') === '1';
+        $valid_before_buffer_option = get_option('x402_paywall_valid_before_buffer', 6);
+        $valid_before_buffer = function_exists('absint')
+            ? absint($valid_before_buffer_option)
+            : (int) $valid_before_buffer_option;
+        $enable_evm = get_option('x402_paywall_enable_evm', '1') === '1';
+        $enable_spl = get_option('x402_paywall_enable_spl', '1') === '1';
+
+        $config = array(
+            'network' => 'mainnet',
+            'api_endpoint' => $facilitator_url,
+            'facilitator_url' => $facilitator_url,
+            'auto_settle' => $auto_settle,
+            'valid_before_buffer' => $valid_before_buffer,
+            'enable_evm' => $enable_evm,
+            'enable_spl' => $enable_spl,
+            'timeout' => 30,
+            'verify_ssl' => true,
+        );
+
+        return apply_filters('x402_client_config', $config);
+    }
+
+    /**
+     * Get configuration array used to initialize the client
+     *
+     * @return array
+     */
+    public function get_config() {
+        return $this->config;
+    }
+
     /**
      * Check if library is available
      *

--- a/tests/integration/test-x402-client-config.php
+++ b/tests/integration/test-x402-client-config.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Basic integration test to ensure administrator settings feed the X402 client configuration.
+ */
+
+declare(strict_types=1);
+
+// Bootstrap minimal WordPress-like environment for the client wrapper.
+define('ABSPATH', __DIR__);
+define('X402_PAYWALL_PLUGIN_DIR', dirname(__DIR__, 2) . '/');
+
+// Option storage for the test environment.
+$GLOBALS['x402_test_options'] = array(
+    'x402_paywall_facilitator_url' => 'https://facilitator.test',
+    'x402_paywall_auto_settle' => '0',
+    'x402_paywall_valid_before_buffer' => '42',
+    'x402_paywall_enable_evm' => '0',
+    'x402_paywall_enable_spl' => '1',
+);
+
+function get_option($name, $default = false) {
+    $options = $GLOBALS['x402_test_options'];
+    return array_key_exists($name, $options) ? $options[$name] : $default;
+}
+
+function apply_filters($tag, $value) {
+    return $value;
+}
+
+function do_action($tag, ...$args) {
+    // No-op for the test environment.
+}
+
+function add_action($tag, $callback) {
+    // No-op for the test environment.
+}
+
+function is_admin() {
+    return false;
+}
+
+function absint($value) {
+    return (int) abs((int) $value);
+}
+
+require_once dirname(__DIR__, 2) . '/includes/class-x402-paywall-x402-client.php';
+
+$client = X402_Paywall_X402_Client::get_instance();
+$config = $client->get_config();
+
+$expected = array(
+    'network' => 'mainnet',
+    'api_endpoint' => 'https://facilitator.test',
+    'facilitator_url' => 'https://facilitator.test',
+    'auto_settle' => false,
+    'valid_before_buffer' => 42,
+    'enable_evm' => false,
+    'enable_spl' => true,
+    'timeout' => 30,
+    'verify_ssl' => true,
+);
+
+$missing = array();
+$wrong = array();
+
+foreach ($expected as $key => $value) {
+    if (!array_key_exists($key, $config)) {
+        $missing[] = $key;
+        continue;
+    }
+
+    if ($config[$key] !== $value) {
+        $wrong[$key] = array('expected' => $value, 'actual' => $config[$key]);
+    }
+}
+
+if ($missing || $wrong) {
+    if ($missing) {
+        fwrite(STDERR, 'Missing config keys: ' . implode(', ', $missing) . PHP_EOL);
+    }
+    if ($wrong) {
+        foreach ($wrong as $key => $values) {
+            fwrite(
+                STDERR,
+                sprintf(
+                    'Value mismatch for %s. Expected %s but received %s%s',
+                    $key,
+                    var_export($values['expected'], true),
+                    var_export($values['actual'], true),
+                    PHP_EOL
+                )
+            );
+        }
+    }
+    exit(1);
+}
+
+echo "X402 client configuration test passed." . PHP_EOL;


### PR DESCRIPTION
## Summary
- update the X402 client wrapper to build its configuration from the paywall settings that administrators manage
- expose the resolved configuration for diagnostics and future hooks
- add an integration smoke test to confirm option values flow into the client configuration

## Testing
- php tests/integration/test-x402-client-config.php

------
https://chatgpt.com/codex/tasks/task_b_6905f3fc9fe48332a9bf16935b1adc91